### PR TITLE
Added C++14-specific operator delete

### DIFF
--- a/src/memory.cc
+++ b/src/memory.cc
@@ -151,4 +151,21 @@ void operator delete[](void * ptr) NOEXCEPT
 	::operator delete(ptr);
 }
 
+// C++14 additional delete operators
 
+#if __cplusplus >= 201103L
+
+__attribute__((weak))
+void operator delete(void * ptr, std::size_t) NOEXCEPT
+{
+	::operator delete(ptr);
+}
+
+
+__attribute__((weak))
+void operator delete[](void * ptr, std::size_t) NOEXCEPT
+{
+	::operator delete(ptr);
+}
+
+#endif

--- a/src/memory.cc
+++ b/src/memory.cc
@@ -153,7 +153,7 @@ void operator delete[](void * ptr) NOEXCEPT
 
 // C++14 additional delete operators
 
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201402L
 
 __attribute__((weak))
 void operator delete(void * ptr, std::size_t) NOEXCEPT


### PR DESCRIPTION
This adds two forms of `operator delete` required for C++14, and enables the code to build with C++ 6.3. 